### PR TITLE
PS-2219 Change public port to 8888

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY docker/sync-api.conf /etc/apache2/sites-available/
 COPY docker/ports.conf /etc/apache2/ports.conf
 COPY docker/php-prod.ini /usr/local/etc/php/php.ini
 
-EXPOSE 8080
+EXPOSE 8888
 
 # configure apache & php
 RUN a2enmod rewrite \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     tty: true
     stdin_open: true
     ports:
-      - "8080:8080"
+      - "8888:8888"
     volumes:
       - ./tests/data:/data/
       - .:/code/

--- a/docker/ports.conf
+++ b/docker/ports.conf
@@ -2,7 +2,7 @@
 # have to change the VirtualHost statement in
 # /etc/apache2/sites-enabled/000-default.conf
 
-Listen 8080
+Listen 8888
 
 <IfModule ssl_module>
 	Listen 443

--- a/docker/sync-api.conf
+++ b/docker/sync-api.conf
@@ -1,4 +1,4 @@
-<VirtualHost *:8080>
+<VirtualHost *:8888>
     ServerName sync-api.local
     ServerAdmin webmaster@localhost
 
@@ -8,7 +8,7 @@
         Order Allow,Deny
         Allow from All
         Require all granted
-        
+
         FallbackResource /index.php
     </Directory>
 


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-2219

The port `8080` is newly used by `data-loader-api` in `sandboxes` and pod can't run multiple containers on the same port. Other Jupyter containers uses port `8888` so I changed this one to unify that.

I expect this sandbox is used just for testing, so it should not be an issue to change the port?